### PR TITLE
Hotfix 0.1.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Create a new release
 on:
   workflow_dispatch:
     inputs:
+      branch:
+        default: 'main'
+        description: 'Branch to release from'
       releaseTag:
         description: 'Release Tag'
         required: true
@@ -17,6 +20,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v4
+        ref: ${{ inputs.branch }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/cache@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "email_auth_provider"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "argon2",
  "bytes",
@@ -498,7 +498,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mobile_auth_provider"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "argon2",
  "bytes",

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -21,13 +21,12 @@ pub fn validate_identity(
 
 pub fn session_cookie(sid: &str, host: ft_sdk::Host) -> Result<http::HeaderValue, ft_sdk::Error> {
     // DO NOT CHANGE THINGS HERE, consult logout code in fastn.
-    let secure_cookies = option_env!("DEV_USE_HTTP_COOKIES").is_none();
     let cookie = cookie::Cookie::build((ft_sdk::auth::SESSION_KEY, sid))
         .domain(host.without_port())
         .path("/")
         .max_age(cookie::time::Duration::seconds(34560000))
         // Secure is required in cross-origin requests otherwise browsers will ignore it
-        .secure(secure_cookies) // Secure cookies only on production
+        .secure(true)
         .build();
 
     Ok(http::HeaderValue::from_str(cookie.to_string().as_str())?)

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -21,7 +21,7 @@ pub fn validate_identity(
 
 pub fn session_cookie(sid: &str, host: ft_sdk::Host) -> Result<http::HeaderValue, ft_sdk::Error> {
     // DO NOT CHANGE THINGS HERE, consult logout code in fastn.
-    let secure_cookies = option_env!("DEV_USE_SECURE_COOKIES").is_none();
+    let secure_cookies = option_env!("DEV_USE_HTTP_COOKIES").is_none();
     let cookie = cookie::Cookie::build((ft_sdk::auth::SESSION_KEY, sid))
         .domain(host.without_port())
         .path("/")

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -21,11 +21,13 @@ pub fn validate_identity(
 
 pub fn session_cookie(sid: &str, host: ft_sdk::Host) -> Result<http::HeaderValue, ft_sdk::Error> {
     // DO NOT CHANGE THINGS HERE, consult logout code in fastn.
+    let secure_cookies = option_env!("DEV_USE_SECURE_COOKIES").is_none();
     let cookie = cookie::Cookie::build((ft_sdk::auth::SESSION_KEY, sid))
         .domain(host.without_port())
         .path("/")
         .max_age(cookie::time::Duration::seconds(34560000))
-        .same_site(cookie::SameSite::Strict)
+        // Secure is required in cross-origin requests otherwise browsers will ignore it
+        .secure(secure_cookies) // Secure cookies only on production
         .build();
 
     Ok(http::HeaderValue::from_str(cookie.to_string().as_str())?)

--- a/email-auth-provider/Cargo.toml
+++ b/email-auth-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "email_auth_provider"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 description = "Email auth provider"

--- a/mobile-auth-provider/Cargo.toml
+++ b/mobile-auth-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile_auth_provider"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 description = "Mobile auth provider"
 


### PR DESCRIPTION
The auth cookie is not attached to a request in cross-origin contexts.
This is bad as we can't link to a website that is relying on auth data
from another website.

Auth cookies are in general Non Strict but Secure.

This is provided as a direct change on the tip of 0.1.2 version so that
websites currently on 0.1.2 can upgrade to this. A major release with
`main` will be made in future with a proper release plan.